### PR TITLE
Disable optimisations for WASM on CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build
         run: cargo build
       - name: Build WASM
-        run: wasm-pack build --target web ./pack-wasm
+        run: wasm-pack build --dev --target web ./pack-wasm
       - name: Run clippy
         run: cargo clippy -- --deny warnings
 


### PR DESCRIPTION
This uses ~60s per CI invocation on optimising code that's only being built to find compilation errors.