### PR TITLE
Fix mangled copyright header comment in XML

### DIFF
--- a/advanced-examples/pack-from-java/PackFromJava/app/src/main/res/xml/data_extraction_rules.xml
+++ b/advanced-examples/pack-from-java/PackFromJava/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
 <!--
  Copyright 2025 Google LLC
 
@@ -15,6 +15,7 @@
  limitations under the License.
 -->
 
+<!--
    Sample data extraction rules file; uncomment and customize as necessary.
    See https://developer.android.com/about/versions/12/backup-restore#xml-changes
    for details.


### PR DESCRIPTION
This caused the example project to fail to build.