### PR TITLE
Change APK buffer from &mut [u8] to &[u8]

### DIFF
--- a/pack-api/src/lib.rs
+++ b/pack-api/src/lib.rs
@@ -137,8 +137,8 @@ pub fn compile_apk(package: &Package) -> Result<Vec<u8>> {
 ///
 /// The APK is built and signed in-memory without using the local filesystem.
 pub fn compile_and_sign_apk(package: &Package, keys: &Keys) -> Result<Vec<u8>> {
-    let mut zip_buf = compile_apk(package)?;
-    pack_sign::sign_apk_buffer(&mut zip_buf, keys)
+    let zip_buf = compile_apk(package)?;
+    pack_sign::sign_apk_buffer(&zip_buf, keys)
 }
 
 /// Performs all the steps in packaging an AAB (Android App Bundle).
@@ -192,7 +192,7 @@ pub fn compile_and_sign_aab(package: &Package, keys: &Keys) -> Result<Vec<u8>> {
     pack_zip::zip_apk(&aab_files, aab_buf_cursor)?;
 
     // Sign the AAB with Scheme v2 and v3 (post-zip)
-    pack_sign::sign_apk_buffer(&mut aab_buf, keys)
+    pack_sign::sign_apk_buffer(&aab_buf, keys)
 }
 
 fn parse_manifest(

--- a/pack-sign/src/hasher.rs
+++ b/pack-sign/src/hasher.rs
@@ -26,7 +26,7 @@ pub const FIRST_LEVEL_CHUNK_MAGIC: &[u8] = &[0xa5];
 pub const SECOND_LEVEL_CHUNK_MAGIC: &[u8] = &[0x5a];
 
 pub fn compute_top_level_hash(
-    apk_buf: &mut [u8],
+    apk_buf: &[u8],
     offsets: &ZipOffsets,
     signing_block_length: usize
 ) -> Result<Sha256Hash> {
@@ -44,7 +44,7 @@ pub fn compute_top_level_hash(
 }
 
 fn compute_first_level_hashes(
-    apk_buf: &mut [u8],
+    apk_buf: &[u8],
     offsets: &ZipOffsets,
     signing_block_length: usize
 ) -> Result<Vec<Sha256Hash>> {
@@ -72,7 +72,9 @@ fn compute_first_level_hashes(
     first_level_hashes.extend(hash_chunk(chunk4));
 
     let new_cd_start = offsets.cd_start + signing_block_length;
-    let mut cursor = Cursor::new(&mut apk_buf[chunk4_range]);
+
+    let mut chunk4_modified = chunk4.to_vec();
+    let mut cursor = Cursor::new(&mut chunk4_modified);
     cursor.seek(SeekFrom::Start(16))?;
     cursor.write_all(&(new_cd_start as u32).to_le_bytes())?;
 

--- a/pack-sign/src/lib.rs
+++ b/pack-sign/src/lib.rs
@@ -34,7 +34,7 @@ mod zip_rebuilder;
 // APK Signature Scheme v3 based on https://source.android.com/docs/security/features/apksigning/v3
 /// Signs a ZIP file buffer, adding an APK Signature Block before its Central Directory.
 /// Can be used for both APK and AAB files.
-pub fn sign_apk_buffer(apk_buf: &mut [u8], keys: &Keys) -> Result<Vec<u8>> {
+pub fn sign_apk_buffer(apk_buf: &[u8], keys: &Keys) -> Result<Vec<u8>> {
     // Dry-run the block to figure out how long it will be given our key
     let dry_run = compute_signing_block([0; 32], keys)?;
     let signing_block_size = dry_run.to_bytes()?.len();


### PR DESCRIPTION
This change makes `sign_apk_buffer` API cleaner and safer by removing the need for &mut [u8] input. The signing pipeline now operates on immutable input data (&[u8]), improving API ergonomics and eliminating misleading mutability requirements.

In usage under production load, consumers of the library were required to create a full mutable copy of the entire APK buffer in order to satisfy the previous &mut [u8] API constraint. Now it is not needed.

It also changes `compute_first_level_hashes` function.

We now only allocate memory for Chunk 4 (EOCD section of the ZIP), which is the only smallest part that requires modification. All other ZIP chunks are processed as zero-copy slices of the input buffer.