### PR TITLE
Store native libraries uncompressed and page-aligned

### DIFF
--- a/pack-zip/src/lib.rs
+++ b/pack-zip/src/lib.rs
@@ -23,6 +23,21 @@ pub struct File {
 
 const UNCOMPRESSED_FILES: &[&str] = &["resources.arsc"];
 
+// Android requires native libraries to be stored uncompressed and aligned to a page
+// boundary before it will `mmap` them straight out of the APK/AAB instead of extracting a
+// copy to disk (`android:extractNativeLibs="false"`). 16 KiB covers both the traditional
+// 4 KiB page size and the 16 KiB page size newer devices require.
+const NATIVE_LIB_ALIGNMENT: u16 = 16384;
+
+// Matches `lib/<abi>/*.so` (APK) and `base/lib/<abi>/*.so` (AAB base module) — the two
+// layouts native libraries are staged under, without depending on any particular ABI name.
+fn is_native_lib(path: &str) -> bool {
+    let segments: Vec<&str> = path.split('/').collect();
+    segments.len() >= 3
+        && segments[segments.len() - 3] == "lib"
+        && segments[segments.len() - 1].ends_with(".so")
+}
+
 // Output can be a file *or* a buffer in memory
 pub fn zip_apk<T: Write + Seek>(files: &[File], output: T) -> Result<()> {
     let mut zip = ZipWriter::new(output);
@@ -34,9 +49,14 @@ pub fn zip_apk<T: Write + Seek>(files: &[File], output: T) -> Result<()> {
     let uncompressed_options = SimpleFileOptions::default()
         .compression_method(CompressionMethod::Stored)
         .with_alignment(4);
+    let native_lib_options = SimpleFileOptions::default()
+        .compression_method(CompressionMethod::Stored)
+        .with_alignment(NATIVE_LIB_ALIGNMENT);
 
     for file in files {
-        let options = if UNCOMPRESSED_FILES.contains(&&file.path[..]) {
+        let options = if is_native_lib(&file.path) {
+            native_lib_options
+        } else if UNCOMPRESSED_FILES.contains(&&file.path[..]) {
             uncompressed_options
         } else {
             compressed_options
@@ -47,4 +67,86 @@ pub fn zip_apk<T: Write + Seek>(files: &[File], output: T) -> Result<()> {
 
     zip.finish()?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn packed(files: &[File]) -> zip::ZipArchive<Cursor<Vec<u8>>> {
+        let mut buf = Cursor::new(Vec::new());
+        zip_apk(files, &mut buf).unwrap();
+        zip::ZipArchive::new(buf).unwrap()
+    }
+
+    #[test]
+    fn native_libs_are_stored_uncompressed_and_page_aligned() {
+        let files = [
+            File {
+                path: "lib/arm64-v8a/libkite.so".into(),
+                data: b"not really an elf".to_vec()
+            },
+            File {
+                path: "base/lib/x86_64/libkite.so".into(),
+                data: b"nor this one".to_vec()
+            }
+        ];
+        let mut zip = packed(&files);
+        for i in 0..zip.len() {
+            let entry = zip.by_index(i).unwrap();
+            assert_eq!(
+                entry.compression(),
+                CompressionMethod::Stored,
+                "{}",
+                entry.name()
+            );
+            assert_eq!(
+                entry.data_start() % u64::from(NATIVE_LIB_ALIGNMENT),
+                0,
+                "{} not aligned to {NATIVE_LIB_ALIGNMENT}",
+                entry.name()
+            );
+        }
+    }
+
+    #[test]
+    fn resources_arsc_still_stored_uncompressed_and_native_libs_stay_out_of_it() {
+        let files = [File {
+            path: "resources.arsc".into(),
+            data: b"arsc".to_vec()
+        }];
+        let mut zip = packed(&files);
+        assert_eq!(
+            zip.by_index(0).unwrap().compression(),
+            CompressionMethod::Stored
+        );
+    }
+
+    #[test]
+    fn ordinary_files_are_still_deflated() {
+        let files = [File {
+            path: "AndroidManifest.xml".into(),
+            data: b"<manifest/>".to_vec()
+        }];
+        let mut zip = packed(&files);
+        assert_eq!(
+            zip.by_index(0).unwrap().compression(),
+            CompressionMethod::Deflated
+        );
+    }
+
+    #[test]
+    fn is_native_lib_matches_apk_and_aab_layouts_only() {
+        assert!(is_native_lib("lib/arm64-v8a/libkite.so"));
+        assert!(is_native_lib("base/lib/x86_64/libpython3.14.so"));
+        // right extension, but "lib" isn't the ABI directory's parent
+        assert!(!is_native_lib("assets/notlib/arm64-v8a/libfoo.so"));
+        // "lib" appears, but not three segments from the end
+        assert!(!is_native_lib("some/lib/deep/path/file.so"));
+        // right directory shape, wrong extension
+        assert!(!is_native_lib("lib/arm64-v8a/readme.txt"));
+        assert!(!is_native_lib("resources.arsc"));
+        assert!(!is_native_lib("classes.dex"));
+    }
 }


### PR DESCRIPTION
`android:extractNativeLibs="false"` lets the platform `mmap` a native library
straight out of the APK/AAB instead of extracting a copy to app-private
storage at install time, but it only works if the library's zip entry is
stored (not deflated) and its data starts on a page boundary. Today every
entry except `resources.arsc` goes through the `Deflated` path with 4-byte
alignment, so that manifest flag isn't reachable.

This adds native-library detection matching both the APK layout
(`lib/<abi>/*.so`) and the AAB base-module layout (`base/lib/<abi>/*.so`,
kept generic instead of hardcoding known ABI names) and stores those
entries uncompressed with 16 KiB alignment — large enough to satisfy both
the traditional 4 KiB page size and the 16 KiB page size newer devices
require.

Non-native-library files are unaffected: `resources.arsc` keeps its
existing stored/4-byte-aligned handling, everything else still deflates.

Tested:
- 4 new unit tests in `pack-zip` (compression method, page alignment,
  path-matching edge cases for both APK and AAB layouts)
- Full workspace `cargo test --workspace --lib --bins` passes unmodified
  (the one pre-existing `pack-api` doctest failure is unrelated — it fails
  identically on `main` before this change)
- `cargo +nightly fmt --check` clean
- Verified against a real downstream consumer: repacked and re-signed with
  this branch, output still passes real `apksigner verify` (v2+v3),
  `zipalign -c`, and `aapt2 dump packagename`
